### PR TITLE
fix OutOfMemoryError: ignore missing nodes of incomplete ways

### DIFF
--- a/src/MapSplit.java
+++ b/src/MapSplit.java
@@ -314,7 +314,11 @@ public class MapSplit {
 		for (WayNode wayNode : way.getWayNodes()) {
 			// get tileNrs for given node
 			long tile = nmap.get(wayNode.getNodeId());
-			
+
+			// ignore missing nodes (extract with incomplete ways)
+			if (tile == 0)
+				continue;
+
 			// mark tiles (and possible neighbours) as modified
 			if (modified) {
 				int tx = nmap.tileX(tile);


### PR DESCRIPTION
Running Mapsplit on [karlsruhe.osm.pbf](http://osm-extracted-metros.s3.amazonaws.com/karlsruhe.osm.pbf) from [Metro Extracts](http://metro.teczno.com/#karlsruhe) results in an OutOfMemoryError (with -Xmx1600M):

```
way = 4293687, nodes = 688, tileList = [-8803764864590807040, -8803764589712900096, -8801513339655028736, -8801513064777121792, -8801512789899214848, -8799261539841343488, -8799261264963436544, -8799260990085529600]
sizeX = 7, sizeY = 7, helperSet: {17, 18, 23, 24, 25, 30, 31, 32}
way = 5173051, nodes = 868, tileList = [-8803762115811737600, -8803761840933830656, -8803761840933814272, -8801510315998052352, -8801510041120145408, -8801510041120137216, -8801510041119621120, -8801509766242238464, -8801509766242238208, -8799257966428553216, 0]
sizeX = 4289, sizeY = 2827, helperSet: {8580, 12107842, 12107843, 12112131, 12112132, 12116421, 12116422}
Exception in thread "Thread-0" java.lang.OutOfMemoryError: Java heap space
  at java.util.Arrays.copyOf(Arrays.java:2760)
  at java.util.Arrays.copyOf(Arrays.java:2734)
  at java.util.Vector.ensureCapacityHelper(Vector.java:226)
  at java.util.Vector.addElement(Vector.java:573)
  at java.util.Stack.push(Stack.java:50)
  at MapSplit.checkAndFill(MapSplit.java:220)
  at MapSplit.addWayToMap(MapSplit.java:342)
  at MapSplit.access$3(MapSplit.java:307)
  at MapSplit$1.process(MapSplit.java:505)
  at crosby.binary.osmosis.OsmosisBinaryParser.parseWays(OsmosisBinaryParser.java:172)
  at crosby.binary.BinaryParser.parse(Unknown Source)
  at crosby.binary.BinaryParser.handleBlock(Unknown Source)
  at crosby.binary.file.FileBlock.process(Unknown Source)
  at crosby.binary.file.BlockInputStream.process(Unknown Source)
  at crosby.binary.osmosis.OsmosisReader.run(OsmosisReader.java:37)
  at java.lang.Thread.run(Thread.java:662)
Exception in thread "main" java.io.IOException: Could not read file fully
  at MapSplit.setup(MapSplit.java:535)
  at MapSplit.run(MapSplit.java:848)
  at MapSplit.main(MapSplit.java:1052)
```

Additional debug output is from the [debug Branch](https://github.com/nrenner/mapsplit/compare/master...debug) and illustrates the problem:

The tileList for way 5173051 contains a tile value of "0" which leads to wrong tile calculations in checkAndFill. The reason is that the extract does not include nodes outside the bounding box, see [way 5173051 with bbox](http://www.openstreetmap.org/?way=5173051&box=yes&minlon=7.893&minlat=48.730&maxlon=8.816&maxlat=49.246), an example node is [60657584](http://www.openstreetmap.org/?node=60657584&box=yes&minlon=7.893&minlat=48.730&maxlon=8.816&maxlat=49.246).
