### PR TITLE
BUG: optimization of sparse tiles

### DIFF
--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -877,11 +877,12 @@ public class MapSplit {
             if (!zoomMap.containsKey(key)) { // not mapped
                 if (value < nodeLimit) {
                     CountResult prevResult = null;
-                    for (int z = 1; z < 5; z++) {
+                    int maxZoomOutDiff = 5;
+                    for (int z = 1; z < maxZoomOutDiff; z++) {
                         int newZoom = zoom - z;
                         CountResult result = getCounts(key, z, stats);
                         if (result.total < 4 * nodeLimit) {
-                            if (result.total > nodeLimit) {
+                            if (result.total > nodeLimit || z == (maxZoomOutDiff - 1)) {
                                 for (int i = 0; i < result.keys.length; i++) {
                                     if (result.counts[i] != null) {
                                         zoomMap.put(result.keys[i], (byte) newZoom);

--- a/src/test/java/dev/osm/mapsplit/SplitTest.java
+++ b/src/test/java/dev/osm/mapsplit/SplitTest.java
@@ -53,6 +53,23 @@ public class SplitTest {
     }
 
     /**
+     * Basic test to check that sparse tiles are optimized correctly
+     */
+    @Test
+    public void splitOptimizeSparseTiles() {
+        try {
+            File output = new File(MSF_OUTPUT_FILENAME);
+            Assert.assertFalse(output.exists());
+            MapSplit.main(new String[] { "-mtvM", "-i", TEST_DATA_PBF, "-o", MSF_OUTPUT_FILENAME, "-f", "2000", "-z", "16", "-O", "20000000" });
+            checkMetadata(12, 12);
+            Tile t = getTile(12, 2143, 1439);
+            Assert.assertNotNull(t);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
      * Basic test to check that stuff happens, with full relations
      */
     @Test


### PR DESCRIPTION
Fixes a bug where tiles with the combined node count below the node
limit were not merged at the most zoomed out level