### PR TITLE
Moar nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ OpenStreetMap and the magnifying glass logo are trademarks of the OpenStreetMap 
                           and '%z' that will be replaced with the tile zoom level.
     -p,--polygon <arg>    only save tiles that intersect or lie within the
                           given polygon file.
-    -s,--size <arg>       n,w,r the size for the node-, way- and relation
+    -s,--size <arg>       n,w,r the initial size for the node-, way- and relation
                           maps to use (should be at least twice the number of
                           IDs). If not supplied, defaults will be used.
     -t,--timing           output timing information

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'java'
 apply plugin: "jacoco"
 apply plugin: 'eclipse'
 
-version = '0.3.0'
+version = '0.4.0'
 
 repositories {
     jcenter()
@@ -58,7 +58,7 @@ sonarqube {
 }
 
 test{
-    maxHeapSize = "6G"
+    maxHeapSize = "12G"
 }
 
 dependencies {
@@ -69,6 +69,7 @@ dependencies {
     compile 'org.imintel:mbtiles4j:1.1.0'
     compile 'org.jetbrains:annotations:15.0'
     compile 'com.zaxxer:SparseBitSet:1.1'
+    compile 'org.xerial.larray:larray_2.12:0.4.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -157,7 +157,7 @@ public class MapSplit {
      * 
      * @param zoom maximum zoom level to generate tiles for
      * @param appointmentDate only add changes from after this date (doesn't really work)
-     * @param mapSizes sizes of the maps for OSM objects
+     * @param mapSizes initial sizes of the maps for OSM objects
      * @param maxFiles maximum number of files/tiles to keep open at the same time
      * @param border grow tiles (content) by this factor
      * @param inputFile the input PBF file
@@ -1572,7 +1572,7 @@ public class MapSplit {
                 "file containing the date since when tiles are being considered to have changed after the split the latest change in infile is going to be stored in file")
                 .build();
         Option sizeOption = Option.builder("s").longOpt("size").hasArg().desc(
-                "n,w,r the size for the node-, way- and relation maps to use (should be at least twice the number of IDs). If not supplied, defaults will be taken.")
+                "n,w,r the initial size for the node-, way- and relation maps to use (should be at least twice the number of IDs). If not supplied, defaults will be taken.")
                 .build();
         Option inputOption = Option.builder("i").longOpt("input").hasArgs().desc("a file in OSM pbf format").required().build();
         Option outputOption = Option.builder("o").longOpt("output").hasArg().desc(

--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -679,7 +679,15 @@ public class MapSplit {
         }
     }
 
-    private static boolean hasTag(Entity e, String key, String value) {
+    /**
+     * Check if a Entity has a specific tag
+     * 
+     * @param e the Entity
+     * @param key the tag key
+     * @param value the tag value
+     * @return true if the tag is present
+     */
+    private static boolean hasTag(@NotNull Entity e, @Nullable String key, @Nullable String value) {
         return e.getTags().stream().anyMatch(tag -> tag.getKey().equals(key) && tag.getValue().equals(value));
     }
 

--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -166,7 +167,7 @@ public class MapSplit {
      * @param completeAreas include all multipolygon relation member objects in every tile the relation is present in
      *            (very expensive)
      */
-    public MapSplit(int zoom, Date appointmentDate, int[] mapSizes, int maxFiles, double border, File inputFile, boolean completeRelations,
+    public MapSplit(int zoom, Date appointmentDate, long[] mapSizes, int maxFiles, double border, File inputFile, boolean completeRelations,
             boolean completeAreas) {
         this.zoom = zoom;
         this.border = border;
@@ -886,7 +887,9 @@ public class MapSplit {
         // lots of Nodes that are in more than
         // one tile
         Map<Integer, Integer> stats = new HashMap<>();
-        for (long k : nmap.keys()) {
+        Iterator<Long> it = nmap.keyIterator();
+        while (it.hasNext()) {
+            long k = it.next();
             List<Integer> tiles = nmap.getAllTiles(k);
             if (tiles != null) {
                 for (Integer t : tiles) {
@@ -1458,7 +1461,7 @@ public class MapSplit {
      * @throws InterruptedException if one of the Threads was interrupted
      * @throws IOException if IO went wrong
      */
-    private static Date run(int zoom, @NotNull String inputFile, @NotNull String outputBase, @Nullable String polygonFile, int[] mapSizes, int maxFiles,
+    private static Date run(int zoom, @NotNull String inputFile, @NotNull String outputBase, @Nullable String polygonFile, long[] mapSizes, int maxFiles,
             double border, Date appointmentDate, boolean metadata, boolean verbose, boolean timing, boolean completeRelations, boolean completeAreas,
             boolean mbTiles, int nodeLimit) throws IOException, InterruptedException {
 
@@ -1538,7 +1541,7 @@ public class MapSplit {
         boolean completeAreas = false;
         boolean mbTiles = false;
         String dateFile = null;
-        int[] mapSizes = new int[] { Const.NODE_MAP_SIZE, Const.WAY_MAP_SIZE, Const.RELATION_MAP_SIZE };
+        long[] mapSizes = new long[] { Const.NODE_MAP_SIZE, Const.WAY_MAP_SIZE, Const.RELATION_MAP_SIZE };
         int maxFiles = -1;
         double border = 0.0;
         int zoom = 13;
@@ -1546,13 +1549,7 @@ public class MapSplit {
 
         // set up logging
         LogManager.getLogManager().reset();
-        SimpleFormatter fmt = new SimpleFormatter();
-        Handler stdoutHandler = new FlushStreamHandler(System.out, fmt); // NOSONAR
-        stdoutHandler.setLevel(Level.INFO);
-        LOGGER.addHandler(stdoutHandler);
-        Handler stderrHandler = new FlushStreamHandler(System.err, fmt); // NOSONAR
-        stderrHandler.setLevel(Level.WARNING);
-        LOGGER.addHandler(stderrHandler);
+        setupLogging(LOGGER);
 
         // arguments
         Option helpOption = Option.builder("h").longOpt("help").desc("this help").build();
@@ -1644,7 +1641,7 @@ public class MapSplit {
                 String tmp = line.getOptionValue("size");
                 String[] vals = tmp.split(",");
                 for (int j = 0; j < 3; j++) {
-                    mapSizes[j] = Integer.valueOf(vals[j]);
+                    mapSizes[j] = Long.valueOf(vals[j]);
                 }
             }
             if (line.hasOption("b")) {
@@ -1727,5 +1724,20 @@ public class MapSplit {
                 dos.writeUTF(df.format(latest));
             }
         }
+    }
+
+    /**
+     * Set up logging
+     * 
+     * @param the Logger to use
+     */
+    public static void setupLogging(@NotNull Logger logger) {
+        SimpleFormatter fmt = new SimpleFormatter();
+        Handler stdoutHandler = new FlushStreamHandler(System.out, fmt); // NOSONAR
+        stdoutHandler.setLevel(Level.INFO);
+        LOGGER.addHandler(stdoutHandler);
+        Handler stderrHandler = new FlushStreamHandler(System.err, fmt); // NOSONAR
+        stderrHandler.setLevel(Level.WARNING);
+        LOGGER.addHandler(stderrHandler);
     }
 }

--- a/src/main/java/dev/osm/mapsplit/OsmMap.java
+++ b/src/main/java/dev/osm/mapsplit/OsmMap.java
@@ -13,6 +13,7 @@ package dev.osm.mapsplit;
  */
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 public interface OsmMap {
@@ -111,12 +112,12 @@ public interface OsmMap {
      * 
      * @return the capacity of this map
      */
-    public int getCapacity();
+    public long getCapacity();
 
     /**
-     * Return all the keys
+     * Return an Iterator for the keys
      * 
-     * @return a List holding all the keys from the map
+     * @return an Iterator for the keys
      */
-    public List<Long> keys();
+    public Iterator<Long> keyIterator();
 }

--- a/src/main/java/dev/osm/mapsplit/array/JavaArray.java
+++ b/src/main/java/dev/osm/mapsplit/array/JavaArray.java
@@ -1,0 +1,38 @@
+package dev.osm.mapsplit.array;
+
+/**
+ * Wrapper around normal long[]
+ * 
+ * @author simon
+ *
+ */
+public class JavaArray implements PrimitiveLongArray {
+    final long[] array;
+
+    /**
+     * Construct a new instance
+     * 
+     * @param length size of the array
+     */
+    public JavaArray(long length) {
+        if (length > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("can't allocate Java array of size " + length);
+        }
+        array = new long[(int) length];
+    }
+
+    @Override
+    public void set(long index, long value) {
+        array[(int) index] = value;
+    }
+
+    @Override
+    public long get(long index) {
+        return array[(int) index];
+    }
+
+    @Override
+    public long length() {
+        return array.length;
+    }
+}

--- a/src/main/java/dev/osm/mapsplit/array/LargeArray.java
+++ b/src/main/java/dev/osm/mapsplit/array/LargeArray.java
@@ -1,0 +1,69 @@
+package dev.osm.mapsplit.array;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import dev.osm.mapsplit.MapSplit;
+
+public class LargeArray implements PrimitiveLongArray {
+
+    private static final Logger LOGGER = Logger.getLogger(LargeArray.class.getName());
+
+    private final long     length;
+    private final long[][] array;
+    private final int      maxSubArrayLength;
+
+    /**
+     * Construct an array of long that can be larger than standard Javas limits
+     * 
+     * @param length how large the array should be
+     */
+    public LargeArray(long length) {
+        this(Integer.MAX_VALUE/2, length);
+    }
+
+    /**
+     * Construct an array of long that can be larger than standard Javas limits
+     * 
+     * @param maxSubArrayLength max. length of each sub-array, only useful for testing
+     * @param length how large the array should be
+     */
+    public LargeArray(int maxSubArrayLength, long length) {
+        this.length = length;
+        this.maxSubArrayLength = maxSubArrayLength;
+        int arrayCount = (int) (length / maxSubArrayLength);
+        int rest = (int) (length % maxSubArrayLength);
+        final boolean hasRest = rest > 0;
+        if (hasRest) {
+            arrayCount++;
+        }
+        MapSplit.setupLogging(LOGGER);
+        LOGGER.log(Level.INFO, "Allocating LongArray length {0}, {1} sub-arrays", new Object[] { length, arrayCount });
+        array = new long[arrayCount][];
+        for (int i = 0; i < (arrayCount - (hasRest ? 1 : 0)); i++) {
+            array[i] = new long[maxSubArrayLength];
+        }
+        if (hasRest) {
+            array[arrayCount - 1] = new long[rest];
+        }
+    }
+
+    @Override
+    public void set(long index, long value) {
+        int a = (int) (index / maxSubArrayLength);
+        int pos = (int) (index - (a * maxSubArrayLength));
+        array[a][pos] = value;
+    }
+
+    @Override
+    public long get(long index) {
+        int a = (int) (index / maxSubArrayLength);
+        int pos = (int) (index - (a * maxSubArrayLength));
+        return array[a][pos];
+    }
+
+    @Override
+    public long length() {
+        return length;
+    }
+}

--- a/src/main/java/dev/osm/mapsplit/array/MMapLargeArray.java
+++ b/src/main/java/dev/osm/mapsplit/array/MMapLargeArray.java
@@ -1,0 +1,48 @@
+package dev.osm.mapsplit.array;
+
+import java.io.File;
+import java.io.IOException;
+
+import xerial.larray.MappedLByteArray;
+import xerial.larray.japi.LArrayJ;
+import xerial.larray.mmap.MMapMode;
+
+/**
+ * Wrapper around normal long[]
+ * 
+ * @author simon
+ *
+ */
+public class MMapLargeArray implements PrimitiveLongArray {
+    final MappedLByteArray array;
+
+    /**
+     * Construct a new instance
+     * 
+     * @param length size of the array
+     * @throws IOException
+     */
+    public MMapLargeArray(long length) throws IOException {
+        array = LArrayJ.mmap(File.createTempFile("temp", null), MMapMode.PRIVATE);
+    }
+
+    @Override
+    public void set(long index, long value) {
+        array.putLong(index, value);
+    }
+
+    @Override
+    public long get(long index) {
+        return array.getLong(index);
+    }
+
+    @Override
+    public long length() {
+        return array.size();
+    }
+
+    @Override
+    public void free() {
+        array.free();
+    }
+}

--- a/src/main/java/dev/osm/mapsplit/array/OffHeapLargeArray.java
+++ b/src/main/java/dev/osm/mapsplit/array/OffHeapLargeArray.java
@@ -1,0 +1,43 @@
+package dev.osm.mapsplit.array;
+
+import xerial.larray.LLongArray;
+import xerial.larray.japi.LArrayJ;
+
+/**
+ * Wrapper around normal long[]
+ * 
+ * @author simon
+ *
+ */
+public class OffHeapLargeArray implements PrimitiveLongArray {
+    final LLongArray array;
+
+    /**
+     * Construct a new instance
+     * 
+     * @param length size of the array
+     */
+    public OffHeapLargeArray(long length) {
+        array = LArrayJ.newLLongArray(length);
+    }
+
+    @Override
+    public void set(long index, long value) {
+        array.update(index, value);
+    }
+
+    @Override
+    public long get(long index) {
+        return array.apply(index);
+    }
+
+    @Override
+    public long length() {
+        return array.size();
+    }
+    
+    @Override
+    public void free() {
+        array.free();
+    }
+}

--- a/src/main/java/dev/osm/mapsplit/array/PrimitiveLongArray.java
+++ b/src/main/java/dev/osm/mapsplit/array/PrimitiveLongArray.java
@@ -1,0 +1,33 @@
+package dev.osm.mapsplit.array;
+
+public interface PrimitiveLongArray {
+    /**
+     * Set a value at index
+     * 
+     * @param index the position in the array
+     * @param value the value to set
+     */
+    void set(long index, long value);
+
+    /**
+     * Get the value at index
+     * 
+     * @param index the index
+     * @return the array value at index
+     */
+    long get(long index);
+    
+    /**
+     * Get the size of the array
+     * 
+     * @return the size of the array
+     */
+    long length();
+    
+    /**
+     * Release any resources that will not be collected by the GC
+     */
+    default void free() {
+        // NOP
+    }
+}

--- a/src/main/java/dev/osm/mapsplit/array/package-info.java
+++ b/src/main/java/dev/osm/mapsplit/array/package-info.java
@@ -1,0 +1,1 @@
+package dev.osm.mapsplit.array;

--- a/src/test/java/dev/osm/mapsplit/BenchMark.java
+++ b/src/test/java/dev/osm/mapsplit/BenchMark.java
@@ -1,0 +1,125 @@
+package dev.osm.mapsplit;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.imintel.mbtiles4j.MBTilesReadException;
+import org.imintel.mbtiles4j.MBTilesReader;
+import org.imintel.mbtiles4j.Tile;
+import org.imintel.mbtiles4j.model.MetadataEntry;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BenchMark {
+
+    private static final Logger LOGGER = Logger.getLogger(BenchMark.class.getName());
+
+    private static final String MSF_OUTPUT_FILENAME = "build/tmp/tiles/liechtenstein.msf";
+    private static final String MSF_OUTPUT_DIR      = "build/tmp/tiles/";
+    private static final String TEST_DATA_PBF       = "test-data/liechtenstein-latest.osm.pbf";
+
+    /**
+     * Pre-test setup
+     */
+    @Before
+    public void setup() {
+        File output = new File(MSF_OUTPUT_FILENAME);
+        output.delete();
+        File path = new File(MSF_OUTPUT_DIR);
+        path.mkdirs();
+    }
+
+    /**
+     * Basic test to check that stuff happens
+     */
+    @Test
+    public void split() {
+        try {
+            File output = new File(MSF_OUTPUT_FILENAME);
+            Assert.assertFalse(output.exists());
+            long start = System.currentTimeMillis();
+            MapSplit.main(new String[] { "-mtvM", "-i", TEST_DATA_PBF, "-o", MSF_OUTPUT_FILENAME, "-f", "2000", "-z", "16", "-O", "2000" });
+            LOGGER.log(Level.INFO, "Run time {0} ms", System.currentTimeMillis() - start);
+            checkMetadata(12, 16);
+            Tile t = getTile(15, 17250, 11506);
+            Assert.assertNotNull(t);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Check that the metadata in the MBTiles is what we expect
+     * 
+     * @param min min zoom in metadata
+     * @param max max zoom in metadata
+     * @throws MBTilesReadException if we can't read or access the MBTiles file
+     */
+    private void checkMetadata(int min, int max) throws MBTilesReadException {
+        MBTilesReader r = null;
+        try {
+            r = new MBTilesReader(new File(MSF_OUTPUT_FILENAME));
+            MetadataEntry md = r.getMetadata();
+            final Map<String, String> required = new HashMap<>();
+            md.getRequiredKeyValuePairs().forEach(new Consumer<Entry<String, String>>() {
+
+                @Override
+                public void accept(Entry<String, String> e) {
+                    required.put(e.getKey(), e.getValue());
+                }
+
+            });
+            final Map<String, String> custom = new HashMap<>();
+            md.getCustomKeyValuePairs().forEach(new Consumer<Entry<String, String>>() {
+
+                @Override
+                public void accept(Entry<String, String> e) {
+                    custom.put(e.getKey(), e.getValue());
+                }
+
+            });
+            Assert.assertEquals(Const.MSF_MIME_TYPE, required.get("format"));
+            Assert.assertEquals(min, r.getMinZoom());
+            Assert.assertEquals(max, r.getMaxZoom());
+            Assert.assertEquals(1544288785000L, Long.parseLong(custom.get("latest_date")));
+        } finally {
+            if (r != null) {
+                r.close();
+            }
+        }
+    }
+
+    /**
+     * Get a tile from a MSF format file
+     * 
+     * @param z zoom
+     * @param x x tile number
+     * @param y y tile number in google/OSM schema
+     * @return a Tile or null if not found
+     */
+    @Nullable
+    private Tile getTile(int z, int x, int y) {
+        MBTilesReader r = null;
+        int tmsY = Integer.MIN_VALUE;
+        try {
+            r = new MBTilesReader(new File(MSF_OUTPUT_FILENAME));
+            int ymax = 1 << z;
+            tmsY = ymax - y - 1; // TMS scheme
+            return r.getTile(z, x, tmsY);
+        } catch (MBTilesReadException e) {
+            LOGGER.warning(e.getMessage() + " z:" + z + " x:" + x + " y:" + y + "/" + tmsY);
+            return null;
+        } finally {
+            if (r != null) {
+                r.close();
+            }
+        }
+    }
+}

--- a/src/test/java/dev/osm/mapsplit/HeapMapTest.java
+++ b/src/test/java/dev/osm/mapsplit/HeapMapTest.java
@@ -1,7 +1,10 @@
 package dev.osm.mapsplit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
+import java.util.Iterator;
 import java.util.logging.Logger;
 
 import org.junit.Test;
@@ -11,7 +14,7 @@ public class HeapMapTest {
     private static final Logger LOGGER = Logger.getLogger(HeapMapTest.class.getName());
 
     /**
-     * Basic test to check that stuff happens
+     * Basic test to check that get and put work as expected
      */
     @Test
     public void putAndGetTest() {
@@ -35,5 +38,35 @@ public class HeapMapTest {
             assertEquals(y[i], map.tileY(value));
             assertEquals(n[i], map.neighbour(value));
         }
+    }
+    
+    /**
+     * Test using the iterator to iterate over the keys
+     */
+    @Test
+    public void iteratorTest() {
+        OsmMap map = new HeapMap(100);
+        final int testDataSize = 80;
+        long[] keys = new long[testDataSize];
+        int[] x = new int[testDataSize];
+        int[] y = new int[testDataSize];
+        int[] n = new int[testDataSize];
+        for (int i = 0; i < testDataSize; i++) {
+            keys[i] = (long) (Math.random() * Long.MAX_VALUE);
+            x[i] = (int) (Math.random() * Integer.MAX_VALUE) & (int) Const.MAX_TILE_NUMBER;
+            y[i] = (int) (Math.random() * Integer.MAX_VALUE) & (int) Const.MAX_TILE_NUMBER;
+            n[i] = (int) (Math.random() * Integer.MAX_VALUE) & 0x3;
+            map.put(keys[i], x[i], y[i], n[i]);
+        }
+        Iterator<Long> it = map.keyIterator();
+        int count = 0;
+        while (it.hasNext()) {
+            System.out.println(count);
+            Long key = it.next();
+            assertNotNull(key);
+            assertNotEquals(0, map.get(key));
+            count++;
+        }
+        assertEquals(testDataSize, count);
     }
 }

--- a/src/test/java/dev/osm/mapsplit/HeapMapTest.java
+++ b/src/test/java/dev/osm/mapsplit/HeapMapTest.java
@@ -1,0 +1,39 @@
+package dev.osm.mapsplit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+public class HeapMapTest {
+
+    private static final Logger LOGGER = Logger.getLogger(HeapMapTest.class.getName());
+
+    /**
+     * Basic test to check that stuff happens
+     */
+    @Test
+    public void putAndGetTest() {
+        OsmMap map = new HeapMap(100);
+        final int testDataSize = 1000;
+        long[] keys = new long[testDataSize];
+        int[] x = new int[testDataSize];
+        int[] y = new int[testDataSize];
+        int[] n = new int[testDataSize];
+        for (int i = 0; i < testDataSize; i++) {
+            keys[i] = (long) (Math.random() * Long.MAX_VALUE);
+            x[i] = (int) (Math.random() * Integer.MAX_VALUE) & (int) Const.MAX_TILE_NUMBER;
+            y[i] = (int) (Math.random() * Integer.MAX_VALUE) & (int) Const.MAX_TILE_NUMBER;
+            n[i] = (int) (Math.random() * Integer.MAX_VALUE) & 0x3;
+            map.put(keys[i], x[i], y[i], n[i]);
+        }
+        assertEquals(1600, map.getCapacity());
+        for (int i = 0; i < testDataSize; i++) {
+            long value = map.get(keys[i]);
+            assertEquals(x[i], map.tileX(value));
+            assertEquals(y[i], map.tileY(value));
+            assertEquals(n[i], map.neighbour(value));
+        }
+    }
+}

--- a/src/test/java/dev/osm/mapsplit/array/ArrayTest.java
+++ b/src/test/java/dev/osm/mapsplit/array/ArrayTest.java
@@ -1,0 +1,168 @@
+package dev.osm.mapsplit.array;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import dev.osm.mapsplit.array.JavaArray;
+import dev.osm.mapsplit.array.LargeArray;
+import dev.osm.mapsplit.array.PrimitiveLongArray;
+
+public class ArrayTest {
+
+    private static final Logger LOGGER = Logger.getLogger(ArrayTest.class.getName());
+
+    private static final long TEST_DATA_SIZE = 1000000000L;
+
+    /**
+     * Native array
+     */
+    @Test
+    public void nativeTest() {
+        long start = System.currentTimeMillis();
+        long[] array = new long[(int) TEST_DATA_SIZE];
+        LOGGER.log(Level.INFO, "Native allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            array[(int) i] = i;
+        }
+        LOGGER.log(Level.INFO, "Native put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            assertEquals(i, array[(int) i]);
+        }
+        LOGGER.log(Level.INFO, "Native get {0} ms", System.currentTimeMillis() - start);
+    }
+
+    /**
+     * Native array wrapped
+     */
+    @Test
+    public void javaArrayTest() {
+        long start = System.currentTimeMillis();
+        PrimitiveLongArray array = new JavaArray(TEST_DATA_SIZE);
+        LOGGER.log(Level.INFO, "JavaArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "JavaArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "JavaArray get {0} ms", System.currentTimeMillis() - start);
+    }
+
+    /**
+     * LargeArray
+     */
+    @Test
+    public void largeArrayTest() {
+        long start = System.currentTimeMillis();
+        PrimitiveLongArray array = new LargeArray(TEST_DATA_SIZE);
+        LOGGER.log(Level.INFO, "LargeArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "LargeArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "LargeArray get {0} ms", System.currentTimeMillis() - start);
+    }
+
+    /**
+     * LargeArray test with small segments
+     */
+    @Test
+    public void largeArrayTest2() {
+        long start = System.currentTimeMillis();
+        long testDataSize = TEST_DATA_SIZE;
+        PrimitiveLongArray array = new LargeArray(100, testDataSize);
+        LOGGER.log(Level.INFO, "LargeArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < testDataSize; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "LargeArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < testDataSize; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "LargeArray get {0} ms", System.currentTimeMillis() - start);
+    }
+    
+    /**
+     * LargeArray test with small segments
+     */
+    @Test
+    public void largeArrayTest3() {
+        long start = System.currentTimeMillis();
+        long testDataSize = TEST_DATA_SIZE + 55;
+        PrimitiveLongArray array = new LargeArray(100, testDataSize);
+        LOGGER.log(Level.INFO, "LargeArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < testDataSize; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "LargeArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < testDataSize; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "LargeArray get {0} ms", System.currentTimeMillis() - start);
+    }
+    
+    /**
+     * OffHeapLongArray
+     */
+    @Test
+    public void offHeapLargeArrayTest() {
+        long start = System.currentTimeMillis();
+        PrimitiveLongArray array = new OffHeapLargeArray(TEST_DATA_SIZE);
+        LOGGER.log(Level.INFO, "OffHeapLargeArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "OffHeapLargeArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "OffHeapLargeArray get {0} ms", System.currentTimeMillis() - start);
+    }
+    
+    /**
+     * OffHeapLongArray
+     */
+    @Test
+    public void mMapLargeArrayTest() {
+        long start = System.currentTimeMillis();
+        PrimitiveLongArray array = null;
+        try {
+            array = new MMapLargeArray(TEST_DATA_SIZE);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        LOGGER.log(Level.INFO, "MMapLargeArray allocation {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            array.set(i, i);
+        }
+        LOGGER.log(Level.INFO, "MMapLargeArray put {0} ms", System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (long i = 0; i < TEST_DATA_SIZE; i++) {
+            assertEquals(i, array.get(i));
+        }
+        LOGGER.log(Level.INFO, "MMapLargeArray get {0} ms", System.currentTimeMillis() - start);
+    }
+}

--- a/src/test/java/dev/osm/mapsplit/array/package-info.java
+++ b/src/test/java/dev/osm/mapsplit/array/package-info.java
@@ -1,0 +1,1 @@
+package dev.osm.mapsplit.array;


### PR DESCRIPTION
Address the issue that the size of extract we can currently process is limited by Javas hard limit on array size. See https://github.com/simonpoole/mapsplit/issues/15

- [x] grow HeapMap dynamically
- [ ] modify  HeapMap to (perhaps optionally) use a "large array" implementation