### PR TITLE
Change the default output file extension from .pbf to .osm.pbf

### DIFF
--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -71,7 +71,8 @@ public class MapSplit {
 
     private static final String MAPSPLIT_TAG = "mapsplit";
 
-    private static final String PBF_EXT = ".pbf";
+    private static final String PBF_EXT = ".osm.pbf";
+    private static final List<String> KNOWN_PBF_EXTS = List.of(".pbf", ".osm.pbf");
 
     private static final Logger LOGGER = Logger.getLogger(MapSplit.class.getName());
 
@@ -1182,7 +1183,7 @@ public class MapSplit {
                             if (basename.contains("%x") && basename.contains("%y")) {
                                 file = basename.replace("%x", Integer.toString(tileX)).replace("%y", Integer.toString(tileY)).replace("%z",
                                         Integer.toString(currentZoom));
-                                if (!file.endsWith(PBF_EXT)) {
+                                if (!KNOWN_PBF_EXTS.stream().anyMatch(file::endsWith)) {
                                     file = file + PBF_EXT;
                                 }
                             } else {


### PR DESCRIPTION
When outputting single-tile files, mapsplit currently uses *.pbf as the filename extension rather than the standard *.osm.pbf. This causes various compatibility annoyances, such as not being able to open the file in JOSM without renaming it (and the reason for these errors is often not obvious).

This change does not affect mbtiles. The behavior will also be unchanged if the user explicitly includes the .pbf extension as part of their output path argument.