### PR TITLE
Offer an array-based implementation of OsmMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ OpenStreetMap and the magnifying glass logo are trademarks of the OpenStreetMap 
     -t,--timing           output timing information
     -v,--verbose          verbose information during processing
     -M,--mbtiles          store in a MBTiles format sqlite database
+    -x,--max-ids <arg>    n,w,r the maximum id to allow in the node, way and
+                          relation arrays. Using this option will cause
+                          Mapsplit to use a different data structure that is
+                          capable of scaling to the entire planet, but uses a
+                          lot of RAM.
     -z,--zoom <arg>       zoom level to create the tiles at must be between 0 (silly)
                           and 16 (inclusive), default is 13
 

--- a/src/main/java/dev/osm/mapsplit/AbstractOsmMap.java
+++ b/src/main/java/dev/osm/mapsplit/AbstractOsmMap.java
@@ -1,0 +1,363 @@
+package dev.osm.mapsplit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.jetbrains.annotations.NotNull;
+
+//@formatter:off
+/**
+ * provides implementation aspects shared between multiple {@link OsmMap} subtypes,
+ * particularly relating to the interpretation of the map's values.
+ * 
+ * Structure of the values:
+ *
+ *     6                 4                   3    2 2 22
+ *     3                 8                   2    8 7 54
+ *     XXXX XXXX XXXX XXXX YYYY YYYY YYYY YYYY uuuu uNNE nnnn nnnn nnnn nnnn nnnn nnnn
+ *
+ *     X - tile number
+ *     Y - tile number
+ *     u - unused
+ *     N - bits indicating immediate "neigbours"
+ *     E - extended "neighbour" list used
+ *     n - bits for "short" neighbour index, in long list mode used as index
+ *
+ *     Tiles indexed in "short" list (T original tile)
+ *           -  - 
+ *           2  1  0  1  2
+ *       
+ *     -2    0  1  2  3  4
+ *     -1    5  6  7  8  9
+ *      0   10 11  T 12 13
+ *      1   14 15 16 17 18
+ *      2   19 20 21 22 23
+ * 
+ */
+//@formatter:on
+abstract public class AbstractOsmMap implements OsmMap {
+
+    // see HEAPMAP.md for details
+    static final int          TILE_X_SHIFT = 48;
+    static final int          TILE_Y_SHIFT = 32;
+    private static final long TILE_X_MASK  = Const.MAX_TILE_NUMBER << TILE_X_SHIFT;
+    private static final long TILE_Y_MASK  = Const.MAX_TILE_NUMBER << TILE_Y_SHIFT;
+
+    private static final int   TILE_EXT_SHIFT            = 24;
+    private static final long  TILE_EXT_MASK             = 1l << TILE_EXT_SHIFT;
+    private static final long  TILE_MARKER_MASK          = 0xFFFFFFl;
+    private static final int   NEIGHBOUR_SHIFT           = TILE_EXT_SHIFT + 1;
+    private static final long  NEIGHBOUR_MASK            = 3l << NEIGHBOUR_SHIFT;
+    private static final int   INITIAL_EXTENDED_SET_SIZE = 1000;
+
+    private int     extendedBuckets = 0;
+    private int[][] extendedSet     = new int[INITIAL_EXTENDED_SET_SIZE][];
+
+    @Override
+    public int tileX(long value) {
+        return (int) ((value & TILE_X_MASK) >>> TILE_X_SHIFT);
+    }
+
+    @Override
+    public int tileY(long value) {
+        return (int) ((value & TILE_Y_MASK) >>> TILE_Y_SHIFT);
+    }
+
+    @Override
+    public int neighbour(long value) {
+        return (int) ((value & NEIGHBOUR_MASK) >> NEIGHBOUR_SHIFT);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see OsmMap#getAllTiles(long)
+     */
+    @Override
+    public List<Integer> getAllTiles(long key) {
+
+        List<Integer> result;
+        long value = get(key);
+
+        if (value == 0) {
+            return null;
+        }
+
+        int tx = tileX(value);
+        int ty = tileY(value);
+        int neighbour = neighbour(value);
+
+        if ((value & TILE_EXT_MASK) != 0) {
+            int idx = (int) (value & TILE_MARKER_MASK);
+            return asList(extendedSet[idx]);
+
+            /*
+             * TODO: testen, dieser Teil sollte nicht noetig sein, da schon im extendedSet! set.add(tx << 13 | ty); if
+             * ((neighbour & OsmMap.NEIGHBOURS_EAST) != 0) set.add(tx+1 << 13 | ty); if ((neighbour &
+             * OsmMap.NEIGHBOURS_SOUTH) != 0) set.add(tx << 13 | ty+1);
+             * 
+             * return set;
+             */
+        }
+
+        result = parseMarker(value);
+
+        // TODO: some tiles (neighbour-tiles) might be double-included in the list, is this a problem?!
+
+        // add the tile (and possible neighbours)
+        result.add(tx << Const.MAX_ZOOM | ty);
+        if ((neighbour & OsmMap.NEIGHBOURS_EAST) != 0) {
+            result.add((tx + 1) << Const.MAX_ZOOM | ty);
+        }
+        if ((neighbour & OsmMap.NEIGHBOURS_SOUTH) != 0) {
+            result.add(tx << Const.MAX_ZOOM | (ty + 1));
+        }
+
+        return result;
+    }
+
+    /**
+     * creates a value (representing a set of tile coords) from a pair of x/y tile coords and maybe some neighbors
+     * 
+     * @param tileX x tile number
+     * @param tileY y tile number
+     * @param neighbours bit encoded neighbours
+     * @return the value encoding the set of tiles represented by the parameters
+     */
+    protected long createValue(int tileX, int tileY, int neighbours) {
+        return ((long) tileX) << TILE_X_SHIFT | ((long) tileY) << TILE_Y_SHIFT | ((long) neighbours) << NEIGHBOUR_SHIFT;
+    }
+
+    /**
+     * updates a value by adding a set of tiles to it.
+     * Might "overflow" into the list of additional tiles and modify it accordingly.
+     * 
+     * This can be used to implement {@link #update(long, Collection)}.
+     * 
+     * @return  the updated value
+     */
+    protected long updateValue(long originalValue, @NotNull Collection<Long> tiles) {
+
+        long val = originalValue;
+
+        int tx = tileX(val);
+        int ty = tileY(val);
+
+        // neighbour list is already too large so we use the "large store"
+        if ((val & TILE_EXT_MASK) != 0) {
+            int idx = (int) (val & TILE_MARKER_MASK);
+            appendNeighbours(idx, tiles);
+            return originalValue;
+        }
+
+        // create a expanded temp set for neighbourhood tiles
+        Collection<Long> expanded = new TreeSet<>();
+        for (long tile : tiles) {
+            expanded.add(tile);
+
+            long x = tileX(tile);
+            long y = tileY(tile);
+            int neighbour = neighbour(tile);
+
+            if ((neighbour & NEIGHBOURS_EAST) != 0) {
+                expanded.add((x + 1) << TILE_X_SHIFT | y << TILE_Y_SHIFT);
+            }
+            if ((neighbour & NEIGHBOURS_SOUTH) != 0) {
+                expanded.add(x << TILE_X_SHIFT | (y + 1) << TILE_Y_SHIFT);
+            }
+            if (neighbour == NEIGHBOURS_SOUTH_EAST) {
+                expanded.add((x + 1) << TILE_X_SHIFT | (y + 1) << TILE_Y_SHIFT);
+            }
+        }
+
+        // now we use the 24 reserved bits for the tiles list..
+        boolean extend = false;
+        for (long tile : expanded) {
+
+            int tmpX = tileX(tile);
+            int tmpY = tileY(tile);
+
+            if (tmpX == tx && tmpY == ty) {
+                continue;
+            }
+
+            int dx = tmpX - tx + 2;
+            int dy = tmpY - ty + 2;
+
+            int idx = dy * 5 + dx;
+            if (idx >= 12) {
+                idx--;
+            }
+
+            if (dx < 0 || dy < 0 || dx > 4 || dy > 4) {
+                // .. damn, not enough space for "small store"
+                // -> use "large store" instead
+                extend = true;
+                break;
+            } else {
+                val |= 1l << idx;
+            }
+        }
+
+        if (extend) {
+            return extendToNeighbourSet(originalValue, tiles);
+        } else {
+            return val;
+        }
+
+    }
+
+    /**
+     * Start using the list of additional tiles instead of the bits directly in the value
+     * 
+     * @param val the value to extend
+     * @param tiles the List of additional tiles
+     * @return the updated value
+     */
+    private long extendToNeighbourSet(long val, @NotNull Collection<Long> tiles) {
+
+        if ((val & TILE_MARKER_MASK) != 0) {
+            // add current stuff to tiles list
+            List<Integer> tmpList = parseMarker(val);
+            for (int i : tmpList) {
+                long tx = i >>> Const.MAX_ZOOM;
+                long ty = i & Const.MAX_TILE_NUMBER;
+                long temp = tx << TILE_X_SHIFT | ty << TILE_Y_SHIFT;
+
+                tiles.add(temp);
+            }
+
+            // delete old marker from val
+            val &= ~TILE_MARKER_MASK;
+        }
+
+        int cur = extendedBuckets++;
+
+        // if we don't have enough sets, increase the array...
+        if (cur >= extendedSet.length) {
+            if (extendedSet.length >= TILE_MARKER_MASK / 2) { // assumes TILE_MARKER_MASK starts at 0
+                throw new IllegalStateException("Too many extended tile entries to expand");
+            }
+            int[][] tmp = new int[2 * extendedSet.length][];
+            System.arraycopy(extendedSet, 0, tmp, 0, extendedSet.length);
+            extendedSet = tmp;
+        }
+
+        val |= 1l << TILE_EXT_SHIFT;
+        val |= (long) cur;
+
+        extendedSet[cur] = new int[0];
+
+        appendNeighbours(cur, tiles);
+
+        return val;
+    }
+
+    /**
+     * Add tiles to the extended tile list for an element
+     * 
+     * @param index the index in to the array of the tile lists
+     * @param tiles a List containing the tile numbers
+     */
+    private void appendNeighbours(int index, @NotNull Collection<Long> tiles) {
+        int[] old = extendedSet[index];
+        int[] set = new int[4 * tiles.size()];
+        int pos = 0;
+
+        for (long l : tiles) {
+            int tx = tileX(l);
+            int ty = tileY(l);
+            int neighbour = neighbour(l);
+
+            set[pos++] = tx << Const.MAX_ZOOM | ty;
+            if ((neighbour & NEIGHBOURS_EAST) != 0) {
+                set[pos++] = (tx + 1) << Const.MAX_ZOOM | ty;
+            }
+            if ((neighbour & NEIGHBOURS_SOUTH) != 0) {
+                set[pos++] = tx << Const.MAX_ZOOM | (ty + 1);
+            }
+            if (neighbour == NEIGHBOURS_SOUTH_EAST) {
+                set[pos++] = (tx + 1) << Const.MAX_ZOOM | (ty + 1);
+            }
+        }
+
+        int[] result = merge(old, set, pos);
+        extendedSet[index] = result;
+    }
+
+    private List<Integer> parseMarker(long value) {
+        List<Integer> result = new ArrayList<>();
+        int tx = tileX(value);
+        int ty = tileY(value);
+
+        for (int i = 0; i < 24; i++) {
+            // if bit is not set, continue..
+            if (((value >> i) & 1) == 0) {
+                continue;
+            }
+
+            int v = i >= 12 ? i + 1 : i;
+
+            int tmpX = v % 5 - 2;
+            int tmpY = v / 5 - 2;
+
+            result.add((tx + tmpX) << Const.MAX_ZOOM | (ty + tmpY));
+        }
+        return result;
+    }
+
+    /**
+     * Merge two int arrays, removing dupes
+     * 
+     * @param old the original array
+     * @param add the additional array
+     * @param len the additional number of ints to allocate
+     * @return the new array
+     */
+    private static int[] merge(@NotNull int[] old, @NotNull int[] add, int len) {
+        int curLen = old.length;
+        int[] tmp = new int[curLen + len];
+        System.arraycopy(old, 0, tmp, 0, old.length);
+
+        for (int i = 0; i < len; i++) {
+            int toAdd = add[i];
+            boolean contained = false;
+
+            for (int j = 0; j < curLen; j++) {
+                if (toAdd == tmp[j]) {
+                    contained = true;
+                    break;
+                }
+            }
+
+            if (!contained) {
+                tmp[curLen++] = toAdd;
+            }
+        }
+
+        int[] result = new int[curLen];
+        System.arraycopy(tmp, 0, result, 0, curLen);
+
+        return result;
+    }
+
+    /**
+     * Return a list with the contents of an int array
+     * 
+     * @param set the array
+     * @return a List of Integer
+     */
+    @NotNull
+    private static List<Integer> asList(@NotNull int[] set) {
+        List<Integer> result = new ArrayList<>();
+
+        for (int i = 0; i < set.length; i++) {
+            result.add(set[i]);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/dev/osm/mapsplit/ArrayMap.java
+++ b/src/main/java/dev/osm/mapsplit/ArrayMap.java
@@ -29,7 +29,7 @@ public final class ArrayMap extends AbstractOsmMap {
      * additional arrays, only used if the maximum ID is large enough to require it.
      * Not implemented as an array of arrays to avoid the additional indirection.
      */
-    private final @Nullable long[] array1, array2, array3;
+    private final @Nullable long[] array1, array2, array3, array4, array5;
 
     /**
      * only keys in range [0, maxKey] will work
@@ -64,6 +64,20 @@ public final class ArrayMap extends AbstractOsmMap {
             remainingRequiredSize -= array3.length;
         } else {
             array3 = null;
+        }
+
+        if (remainingRequiredSize > 0) {
+            array4 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+            remainingRequiredSize -= array4.length;
+        } else {
+            array4 = null;
+        }
+
+        if (remainingRequiredSize > 0) {
+            array5 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+            remainingRequiredSize -= array5.length;
+        } else {
+            array5 = null;
         }
 
         if (remainingRequiredSize > 0) {
@@ -117,6 +131,8 @@ public final class ArrayMap extends AbstractOsmMap {
         case 1: return array1;
         case 2: return array2;
         case 3: return array3;
+        case 4: return array4;
+        case 5: return array5;
         default: throw new IllegalArgumentException("No array for the key " + key + " exists");
         }
     }

--- a/src/main/java/dev/osm/mapsplit/ArrayMap.java
+++ b/src/main/java/dev/osm/mapsplit/ArrayMap.java
@@ -1,0 +1,129 @@
+package dev.osm.mapsplit;
+
+import static java.lang.Math.min;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * data structure that uses huge arrays with the OSM element's ID (the key) as the array index.
+ * 
+ * Because the number of IDs can (and in the case of nodes does) exceed Java's maximum array size,
+ * additional arrays are used for higher ids.
+ */
+public final class ArrayMap extends AbstractOsmMap {
+
+    /** maximum size for a single array, see e.g. https://stackoverflow.com/a/8381338/ */
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    private final long maxKey;
+
+    /** the basic array for IDs starting at 0. This is always used. */ 
+    private final @NotNull long[] array0;
+
+    /**
+     * additional arrays, only used if the maximum ID is large enough to require it.
+     * Not implemented as an array of arrays to avoid the additional indirection.
+     */
+    private final @Nullable long[] array1, array2, array3;
+
+    /**
+     * only keys in range [0, maxKey] will work
+     * 
+     * @throws IllegalArgumentException  if the requested maximum value is too large
+     */
+    public ArrayMap(long maxKey) {
+
+        this.maxKey = maxKey;
+
+        long remainingRequiredSize = maxKey + 1;
+
+        this.array0 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+        remainingRequiredSize -= this.array0.length;
+
+        if (remainingRequiredSize > 0) {
+            array1 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+            remainingRequiredSize -= array1.length;
+        } else {
+            array1 = null;
+        }
+
+        if (remainingRequiredSize > 0) {
+            array2 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+            remainingRequiredSize -= array2.length;
+        } else {
+            array2 = null;
+        }
+
+        if (remainingRequiredSize > 0) {
+            array3 = new long[(int) min(remainingRequiredSize, MAX_ARRAY_SIZE)];
+            remainingRequiredSize -= array3.length;
+        } else {
+            array3 = null;
+        }
+
+        if (remainingRequiredSize > 0) {
+            throw new IllegalArgumentException("The requested maximum ID is too large for the current implementation");
+        }
+
+    }
+
+    @Override
+    public final void put(long key, int tileX, int tileY, int neighbours) {
+        arrayForKey(key)[indexWithinArray(key)] = createValue(tileX, tileY, neighbours);
+    }
+
+    @Override
+    public final long get(long key) {
+        return arrayForKey(key)[indexWithinArray(key)];
+    }
+
+    @Override
+    public final void update(long key, Collection<Long> tiles) {
+        long[] array = arrayForKey(key);
+        int indexWithinArray = indexWithinArray(key);
+        array[indexWithinArray] = updateValue(array[indexWithinArray], tiles);
+    }
+
+    @Override
+    public final double getMissHitRatio() {
+        return 0;
+    }
+
+    @Override
+    public final long getCapacity() {
+        return maxKey + 1;
+    }
+
+    @Override
+    public final List<Long> keys() {
+        List<Long> result = new ArrayList<>();
+        for (long key = 0; key <= maxKey; key++) {
+            if (get(key) != 0) {
+                result.add(key);
+            }
+        }
+        return result;
+    }
+
+    /** returns the array containing the value associated with [key] */
+    private final long[] arrayForKey(long key) {
+        switch((int) (key / MAX_ARRAY_SIZE)) {
+        case 0: return array0;
+        case 1: return array1;
+        case 2: return array2;
+        case 3: return array3;
+        default: throw new IllegalArgumentException("No array for the key " + key + " exists");
+        }
+    }
+
+    /** returns the index of the value associated with [key], within {@link #arrayForKey(long)} */
+    private static final int indexWithinArray(long key) {
+        return (int) (key % MAX_ARRAY_SIZE);
+    }
+
+}

--- a/src/main/java/dev/osm/mapsplit/HeapMap.java
+++ b/src/main/java/dev/osm/mapsplit/HeapMap.java
@@ -17,69 +17,28 @@ package dev.osm.mapsplit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.TreeSet;
 
 import org.jetbrains.annotations.NotNull;
 
-// @formatter:off
 /**
  * An HashMap in Heap memory, optimized for size to use in OSM
  * 
- * Structure of the values:
- * 
- *     6                 4                   3    2 2 22
- *     3                 8                   2    8 7 54
- *     XXXX XXXX XXXX XXXX YYYY YYYY YYYY YYYY uuuu uNNE nnnn nnnn nnnn nnnn nnnn nnnn
- *
- *     X - tile number
- *     Y - tile number
- *     u - unused
- *     N - bits indicating immediate "neigbours"
- *     E - extended "neighbour" list used
- *     n - bits for "short" neighbour index, in long list mode used as index
- *
- *     Tiles indexed in "short" list (T original tile)
- *           -  - 
- *           2  1  0  1  2
- *       
- *     -2    0  1  2  3  4
- *     -1    5  6  7  8  9
- *      0   10 11  T 12 13
- *      1   14 15 16 17 18
- *      2   19 20 21 22 23
- * 
+ * See {@link AbstractOsmMap} for the meaning of the values.
  */
-// @formatter:on
-@SuppressWarnings("unchecked")
-public class HeapMap implements OsmMap {
+public class HeapMap extends AbstractOsmMap {
 
     // used on keys
     private static final int  BUCKET_FULL_SHIFT = 63;
     private static final long BUCKET_FULL_MASK  = 1l << BUCKET_FULL_SHIFT;
     private static final long KEY_MASK          = ~BUCKET_FULL_MASK;
 
-    // see HEAPMAP.md for details
-    static final int          TILE_X_SHIFT = 48;
-    static final int          TILE_Y_SHIFT = 32;
-    private static final long TILE_X_MASK  = Const.MAX_TILE_NUMBER << TILE_X_SHIFT;
-    private static final long TILE_Y_MASK  = Const.MAX_TILE_NUMBER << TILE_Y_SHIFT;
-
-    private static final int   TILE_EXT_SHIFT            = 24;
-    private static final long  TILE_EXT_MASK             = 1l << TILE_EXT_SHIFT;
-    private static final long  TILE_MARKER_MASK          = 0xFFFFFFl;
-    private static final int   NEIGHBOUR_SHIFT           = TILE_EXT_SHIFT + 1;
-    private static final long  NEIGHBOUR_MASK            = 3l << NEIGHBOUR_SHIFT;
     private static final float DEFAULT_FILL_FACTOR       = 0.75f;
-    private static final int   INITIAL_EXTENDED_SET_SIZE = 1000;
 
     private int capacity;
 
     private int    size = 0;
     private long[] keys;
     private long[] values;
-
-    private int     extendedBuckets = 0;
-    private int[][] extendedSet     = new int[INITIAL_EXTENDED_SET_SIZE][];
 
     private long  hits       = 0;
     private long  misses     = 0;
@@ -127,21 +86,6 @@ public class HeapMap implements OsmMap {
         return capacity;
     }
 
-    @Override
-    public int tileX(long value) {
-        return (int) ((value & TILE_X_MASK) >>> TILE_X_SHIFT);
-    }
-
-    @Override
-    public int tileY(long value) {
-        return (int) ((value & TILE_Y_MASK) >>> TILE_Y_SHIFT);
-    }
-
-    @Override
-    public int neighbour(long value) {
-        return (int) ((value & NEIGHBOUR_MASK) >> NEIGHBOUR_SHIFT);
-    }
-
     /**
      * The hash function
      * 
@@ -165,7 +109,7 @@ public class HeapMap implements OsmMap {
         int count = 0;
 
         int bucket = (int) (KEY(key) % capacity);
-        long value = ((long) tileX) << TILE_X_SHIFT | ((long) tileY) << TILE_Y_SHIFT | ((long) neighbours) << NEIGHBOUR_SHIFT;
+        long value = createValue(tileX, tileY, neighbours);
 
         while (true) {
             if (values[bucket] == 0) {
@@ -237,118 +181,6 @@ public class HeapMap implements OsmMap {
         return values[bucket];
     }
 
-    /**
-     * Merge two int arrays, removing dupes
-     * 
-     * @param old the original array
-     * @param add the additional array
-     * @param len the additional number of ints to allocate
-     * @return the new array
-     */
-    private int[] merge(@NotNull int[] old, @NotNull int[] add, int len) {
-        int curLen = old.length;
-        int[] tmp = new int[curLen + len];
-        System.arraycopy(old, 0, tmp, 0, old.length);
-
-        for (int i = 0; i < len; i++) {
-            int toAdd = add[i];
-            boolean contained = false;
-
-            for (int j = 0; j < curLen; j++) {
-                if (toAdd == tmp[j]) {
-                    contained = true;
-                    break;
-                }
-            }
-
-            if (!contained) {
-                tmp[curLen++] = toAdd;
-            }
-        }
-
-        int[] result = new int[curLen];
-        System.arraycopy(tmp, 0, result, 0, curLen);
-
-        return result;
-    }
-
-    /**
-     * Add tiles to the extended tile list for an element
-     * 
-     * @param index the index in to the array of the tile lists
-     * @param tiles a List containing the tile numbers
-     */
-    private void appendNeighbours(int index, @NotNull Collection<Long> tiles) {
-        int[] old = extendedSet[index];
-        int[] set = new int[4 * tiles.size()];
-        int pos = 0;
-
-        for (long l : tiles) {
-            int tx = tileX(l);
-            int ty = tileY(l);
-            int neighbour = neighbour(l);
-
-            set[pos++] = tx << Const.MAX_ZOOM | ty;
-            if ((neighbour & NEIGHBOURS_EAST) != 0) {
-                set[pos++] = (tx + 1) << Const.MAX_ZOOM | ty;
-            }
-            if ((neighbour & NEIGHBOURS_SOUTH) != 0) {
-                set[pos++] = tx << Const.MAX_ZOOM | (ty + 1);
-            }
-            if (neighbour == NEIGHBOURS_SOUTH_EAST) {
-                set[pos++] = (tx + 1) << Const.MAX_ZOOM | (ty + 1);
-            }
-        }
-
-        int[] result = merge(old, set, pos);
-        extendedSet[index] = result;
-    }
-
-    /**
-     * Start using the list of additional tiles instead of the bits directly in the value
-     * 
-     * @param bucket the index of the value
-     * @param tiles the List of additional tiles
-     */
-    private void extendToNeighbourSet(int bucket, @NotNull Collection<Long> tiles) {
-        long val = values[bucket];
-
-        if ((val & TILE_MARKER_MASK) != 0) {
-            // add current stuff to tiles list
-            List<Integer> tmpList = parseMarker(val);
-            for (int i : tmpList) {
-                long tx = i >>> Const.MAX_ZOOM;
-                long ty = i & Const.MAX_TILE_NUMBER;
-                long temp = tx << TILE_X_SHIFT | ty << TILE_Y_SHIFT;
-
-                tiles.add(temp);
-            }
-
-            // delete old marker from val
-            val &= ~TILE_MARKER_MASK;
-        }
-
-        int cur = extendedBuckets++;
-
-        // if we don't have enough sets, increase the array...
-        if (cur >= extendedSet.length) {
-            if (extendedSet.length >= TILE_MARKER_MASK / 2) { // assumes TILE_MARKER_MASK starts at 0
-                throw new IllegalStateException("Too many extended tile entries to expand");
-            }
-            int[][] tmp = new int[2 * extendedSet.length][];
-            System.arraycopy(extendedSet, 0, tmp, 0, extendedSet.length);
-            extendedSet = tmp;
-        }
-
-        val |= 1l << TILE_EXT_SHIFT;
-        val |= (long) cur;
-        values[bucket] = val;
-
-        extendedSet[cur] = new int[0];
-
-        appendNeighbours(cur, tiles);
-    }
-
     /*
      * (non-Javadoc)
      * 
@@ -361,157 +193,9 @@ public class HeapMap implements OsmMap {
         if (bucket == -1) {
             return;
         }
-        long val = values[bucket];
-        int tx = tileX(val);
-        int ty = tileY(val);
 
-        // neighbour list is already too large so we use the "large store"
-        if ((val & TILE_EXT_MASK) != 0) {
-            int idx = (int) (val & TILE_MARKER_MASK);
-            appendNeighbours(idx, tiles);
-            return;
-        }
+        values[bucket] = updateValue(values[bucket], tiles);
 
-        // create a expanded temp set for neighbourhood tiles
-        Collection<Long> expanded = new TreeSet<>();
-        for (long tile : tiles) {
-            expanded.add(tile);
-
-            long x = tileX(tile);
-            long y = tileY(tile);
-            int neighbour = neighbour(tile);
-
-            if ((neighbour & NEIGHBOURS_EAST) != 0) {
-                expanded.add((x + 1) << TILE_X_SHIFT | y << TILE_Y_SHIFT);
-            }
-            if ((neighbour & NEIGHBOURS_SOUTH) != 0) {
-                expanded.add(x << TILE_X_SHIFT | (y + 1) << TILE_Y_SHIFT);
-            }
-            if (neighbour == NEIGHBOURS_SOUTH_EAST) {
-                expanded.add((x + 1) << TILE_X_SHIFT | (y + 1) << TILE_Y_SHIFT);
-            }
-        }
-
-        // now we use the 24 reserved bits for the tiles list..
-        boolean extend = false;
-        for (long tile : expanded) {
-
-            int tmpX = tileX(tile);
-            int tmpY = tileY(tile);
-
-            if (tmpX == tx && tmpY == ty) {
-                continue;
-            }
-
-            int dx = tmpX - tx + 2;
-            int dy = tmpY - ty + 2;
-
-            int idx = dy * 5 + dx;
-            if (idx >= 12) {
-                idx--;
-            }
-
-            if (dx < 0 || dy < 0 || dx > 4 || dy > 4) {
-                // .. damn, not enough space for "small store"
-                // -> use "large store" instead
-                extend = true;
-                break;
-            } else {
-                val |= 1l << idx;
-            }
-        }
-
-        if (extend) {
-            extendToNeighbourSet(bucket, tiles);
-        } else {
-            values[bucket] = val;
-        }
-    }
-
-    private List<Integer> parseMarker(long value) {
-        List<Integer> result = new ArrayList<>();
-        int tx = tileX(value);
-        int ty = tileY(value);
-
-        for (int i = 0; i < 24; i++) {
-            // if bit is not set, continue..
-            if (((value >> i) & 1) == 0) {
-                continue;
-            }
-
-            int v = i >= 12 ? i + 1 : i;
-
-            int tmpX = v % 5 - 2;
-            int tmpY = v / 5 - 2;
-
-            result.add((tx + tmpX) << Const.MAX_ZOOM | (ty + tmpY));
-        }
-        return result;
-    }
-
-    /**
-     * Return a list with the contents of an int array
-     * 
-     * @param set the array
-     * @return a List of Integer
-     */
-    @NotNull
-    private List<Integer> asList(@NotNull int[] set) {
-        List<Integer> result = new ArrayList<>();
-
-        for (int i = 0; i < set.length; i++) {
-            result.add(set[i]);
-        }
-
-        return result;
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see OsmMap#getAllTiles(long)
-     */
-    @Override
-    public List<Integer> getAllTiles(long key) {
-
-        List<Integer> result;
-        long value = get(key);
-
-        if (value == 0) {
-            return null;
-        }
-
-        int tx = tileX(value);
-        int ty = tileY(value);
-        int neighbour = neighbour(value);
-
-        if ((value & TILE_EXT_MASK) != 0) {
-            int idx = (int) (value & TILE_MARKER_MASK);
-            return asList(extendedSet[idx]);
-
-            /*
-             * TODO: testen, dieser Teil sollte nicht noetig sein, da schon im extendedSet! set.add(tx << 13 | ty); if
-             * ((neighbour & OsmMap.NEIGHBOURS_EAST) != 0) set.add(tx+1 << 13 | ty); if ((neighbour &
-             * OsmMap.NEIGHBOURS_SOUTH) != 0) set.add(tx << 13 | ty+1);
-             * 
-             * return set;
-             */
-        }
-
-        result = parseMarker(value);
-
-        // TODO: some tiles (neighbour-tiles) might be double-included in the list, is this a problem?!
-
-        // add the tile (and possible neighbours)
-        result.add(tx << Const.MAX_ZOOM | ty);
-        if ((neighbour & OsmMap.NEIGHBOURS_EAST) != 0) {
-            result.add((tx + 1) << Const.MAX_ZOOM | ty);
-        }
-        if ((neighbour & OsmMap.NEIGHBOURS_SOUTH) != 0) {
-            result.add(tx << Const.MAX_ZOOM | (ty + 1));
-        }
-
-        return result;
     }
 
     /*

--- a/src/main/java/dev/osm/mapsplit/HeapMap.java
+++ b/src/main/java/dev/osm/mapsplit/HeapMap.java
@@ -82,7 +82,7 @@ public class HeapMap extends AbstractOsmMap {
     }
 
     @Override
-    public int getCapacity() {
+    public long getCapacity() {
         return capacity;
     }
 

--- a/src/main/java/dev/osm/mapsplit/MapSplit.java
+++ b/src/main/java/dev/osm/mapsplit/MapSplit.java
@@ -140,9 +140,17 @@ public class MapSplit {
     public MapSplit(CommandLineParams params, Date appointmentDate) {
         this.params = params;
         this.appointmentDate = appointmentDate;
-        nmap = new HeapMap(params.mapSizes[0]);
-        wmap = new HeapMap(params.mapSizes[1]);
-        rmap = new HeapMap(params.mapSizes[2]);
+
+        if (params.mapSizes != null) {
+            nmap = new HeapMap(params.mapSizes[0]);
+            wmap = new HeapMap(params.mapSizes[1]);
+            rmap = new HeapMap(params.mapSizes[2]);
+        } else {
+            nmap = new ArrayMap(params.maxIds[0]);
+            wmap = new ArrayMap(params.maxIds[1]);
+            rmap = new ArrayMap(params.maxIds[2]);
+        }
+
         if (params.completeRelations || params.completeAreas) {
             extraWayMap = new HashMap<>();
         }
@@ -656,9 +664,9 @@ public class MapSplit {
         return e.getTags().stream().anyMatch(tag -> tag.getKey().equals(key) && tag.getValue().equals(value));
     }
 
-    int nCount = 0;
-    int wCount = 0;
-    int rCount = 0;
+    long nCount = 0;
+    long wCount = 0;
+    long rCount = 0;
 
     /**
      * Setup the OSM object to tiles mappings
@@ -1450,11 +1458,11 @@ public class MapSplit {
         }
 
         if (params.verbose) {
-            LOGGER.log(Level.INFO, "HeapMap's load:");
+            LOGGER.log(Level.INFO, "Load:");
             LOGGER.log(Level.INFO, "Nodes    : {0}", split.nmap.getLoad());
             LOGGER.log(Level.INFO, "Ways     : {0}", split.wmap.getLoad());
             LOGGER.log(Level.INFO, "Relations: {0}", split.rmap.getLoad());
-            LOGGER.log(Level.INFO, "HeapMap's MissHitRatio:");
+            LOGGER.log(Level.INFO, "MissHitRatio:");
             LOGGER.log(Level.INFO, "Nodes    : {0}", nratio);
             LOGGER.log(Level.INFO, "Ways     : {0}", wratio);
             LOGGER.log(Level.INFO, "Relations: {0}", rratio);

--- a/src/main/java/dev/osm/mapsplit/OsmMap.java
+++ b/src/main/java/dev/osm/mapsplit/OsmMap.java
@@ -77,7 +77,9 @@ public interface OsmMap {
      * 
      * @return the load of the map
      */
-    public abstract double getLoad();
+    public default double getLoad() {
+        return keys().size() / getCapacity();
+    }
 
     /**
      * for debugging this method gives the ratio of misses to hits. For open addressing multiple misses may occur. The
@@ -117,7 +119,7 @@ public interface OsmMap {
      * 
      * @return the capacity of this map
      */
-    public int getCapacity();
+    public long getCapacity();
 
     /**
      * Return all the keys

--- a/src/main/java/dev/osm/mapsplit/OsmMap.java
+++ b/src/main/java/dev/osm/mapsplit/OsmMap.java
@@ -15,6 +15,12 @@ package dev.osm.mapsplit;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * This is the central data structure of Mapsplit.
+ * It maps OSM element IDs to the tile(s) each element is located in.
+ * As there are three types of OSM elements (node/way/relation),
+ * there will be three instances of this kind of data structure.
+ */
 public interface OsmMap {
 
     /** no neighbour */
@@ -74,7 +80,7 @@ public interface OsmMap {
     public abstract double getLoad();
 
     /**
-     * for debugging this method gives the ratio of misses to hits. For open addressing multiple misses may occour. The
+     * for debugging this method gives the ratio of misses to hits. For open addressing multiple misses may occur. The
      * ratio gives feedback about the goodness of the data/hash function. A value of 0 means perfect hashing, a value
      * larger 2 means a high load or a bad hash function.
      * 

--- a/src/test/java/dev/osm/mapsplit/ArrayMapTest.java
+++ b/src/test/java/dev/osm/mapsplit/ArrayMapTest.java
@@ -1,0 +1,50 @@
+package dev.osm.mapsplit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class ArrayMapTest {
+
+    @Test
+    public void testPutUpdateAndRetrieve() {
+
+        var map = new ArrayMap(100);
+
+        int tileX = 1245;
+        int tileY = 99;
+
+        /* put some entries into the tile and its eastern neighbor */
+
+        map.put(42, tileX , tileY, OsmMap.NEIGHBOURS_NONE);
+        map.put(0, tileX, tileY, OsmMap.NEIGHBOURS_EAST);
+        map.put(100, tileX + 1, tileY, OsmMap.NEIGHBOURS_NONE);
+
+        /* retrieve the values and tile lists from the map */
+
+        long value42 = map.get(42);
+        assertEquals(tileX, map.tileX(value42));
+        assertEquals(tileY, map.tileY(value42));
+
+        assertEquals(List.of(tileX << 16 | tileY), map.getAllTiles(42));
+        assertEquals(2, map.getAllTiles(0).size());
+
+        /* update one of the values and check again */
+
+        map.update(42, List.of(
+                map.createValue(tileX + 1, tileY, OsmMap.NEIGHBOURS_NONE),
+                map.createValue(tileX, tileY + 1, OsmMap.NEIGHBOURS_NONE)));
+
+        assertEquals(3, map.getAllTiles(42).size());
+
+        /* check the keys */
+
+        assertEquals(Set.of(0l, 42l, 100l), new HashSet<>(map.keys()));
+
+    }
+
+}


### PR DESCRIPTION
_This pull request builds on top of #20_

This is the first major step towards my goal of splitting very large input files.

`OsmMap`, the data structure storing the list of tiles for each OSM element, is responsible for the largest fraction of Mapsplit's memory consumption. Therefore, this pull request introduces an alternative implementation of `OsmMap`. Unlike the existing implementation `HeapMap`, the new `ArrayMap` has a high, but fixed memory consumption. Shared functionality of `HeapMap` and `ArrayMap` is pulled up into an abstract parent class.

The basic idea of `ArrayMap` is very simple: It is a huge array of primitive long values that uses OSM IDs as the array index. The only complication is that Java's size limit for arrays forces me to use more than one array, but it's still a pretty straightforward implementation.

Of course, this data structure is wasteful for a small input file – it uses the same amount of memory whether you split Liechtenstein or the entire planet. Therefore, using `ArrayMap` is opt-in through a new command line parameter, `--max-ids`, which is also used to pass in the current maximum ids for nodes, ways and relations. (This could eventually be replaced with automatic detection of the maximum ids in the input file at the cost of an extra read-through of that file.)

On a standard Hetzner Cloud instance with 128 GB of memory, I was able to split the DACH Geofabrik extract in about an hour using Mapsplit with my `ArrayMap` implementation. With even larger input files, the other data structures grow in size and `OsmMap` is no longer the only factor I have to consider for memory consumption. I plan to tackle these other data structures in future pull requests.